### PR TITLE
Bump TargetFrameworkVersion from v4.5 to v4.5.2

### DIFF
--- a/src/ToyCompany/ToyCompany.Database/ToyCompany.Database.sqlproj
+++ b/src/ToyCompany/ToyCompany.Database/ToyCompany.Database.sqlproj
@@ -16,7 +16,7 @@
     <ModelCollation>1033, CI</ModelCollation>
     <DefaultFileStructure>BySchemaAndSchemaType</DefaultFileStructure>
     <DeployToDatabase>True</DeployToDatabase>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetLanguage>CS</TargetLanguage>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <SqlServerVerification>False</SqlServerVerification>


### PR DESCRIPTION
Developer Pack for .NET Framework v4.5 is not available. You have to upgrade to v4.5.2 or later.

```
Build started 4/5/2022 7:30:05 AM.
Project "D:\a\toy-website-end-to-end\toy-website-end-to-end\src\ToyCompany\ToyCompany.Database\ToyCompany.Database.sqlproj" on node 1 (default targets).
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(1220,5): error MSB3644: The reference assemblies for .NETFramework,Version=v4.5 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [D:\a\toy-website-end-to-end\toy-website-end-to-end\src\ToyCompany\ToyCompany.Database\ToyCompany.Database.sqlproj]
_CleanRecordFileWrites:
  Creating directory "obj\Release\".
Done Building Project "D:\a\toy-website-end-to-end\toy-website-end-to-end\src\ToyCompany\ToyCompany.Database\ToyCompany.Database.sqlproj" (default targets) -- FAILED.

Build FAILED.
```
![fail-build-database](https://user-images.githubusercontent.com/17608272/161704189-ae152cae-0de4-4367-b88e-69f584ccd3e5.png)

